### PR TITLE
Fix WebSocket request address to include port number

### DIFF
--- a/web/src/stream.vue
+++ b/web/src/stream.vue
@@ -6,7 +6,7 @@ let canvas = null;
 let player = null;
 let ctx = null;
 let client = null;
-let host = import.meta.env.VITE_WS_HOST ? import.meta.env.VITE_WS_HOST : window.location.hostname;
+let host = import.meta.env.VITE_WS_HOST ? import.meta.env.VITE_WS_HOST : window.location.host;
 
 onMounted(() => {
 	console.log("init");


### PR DESCRIPTION
Since port 80 is not always available, when the server runs on a non‑80 port, the frontend WebSocket request should include the port number. However, using `location.hostname` only retrieves the hostname. To correctly include the port, `location.host` should be used instead.

This contribution does not include rebuilding of distribution directory. Please run `pnpm build` in the web directory to generate them.